### PR TITLE
add ro-crate configuration

### DIFF
--- a/conf/mhm.yml
+++ b/conf/mhm.yml
@@ -16,6 +16,6 @@
 # under the License.
 
 MHM:
-  BRANCH_NAME: master
+  BRANCH_NAME: develop
   DOMAIN: 1
   EVAL_PERIOD_DURATION_YEARS: 2

--- a/conf/mhm.yml
+++ b/conf/mhm.yml
@@ -16,4 +16,6 @@
 # under the License.
 
 MHM:
+  BRANCH_NAME: master
+  DOMAIN: 1
   EVAL_PERIOD_DURATION_YEARS: 2

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -1,86 +1,91 @@
-ROCRATE: |
-  {
-    "@graph": [
-      {
-        "@id": "./",
-        "license": "Apache-2.0",
-        "creator": {
-          "@id": "https://orcid.org/0000-0001-8250-4074"
-        },
-        "publisher": {
-          "@id": "https://ror.org/05sd8tv96"
-        },
-        "input": [
-          {
-            "@id": "#mhm-input-branch-name"
-          },
-          {
-            "@id": "#mhm-input-domain"
-          },
-          {
-            "@id": "#mhm-input-eval-period-duration-years"
-          }
-        ]
-      },
-      {
-        "@id": "#mhm-input-branch-name",
-        "@type": "FormalParameter",
-        "additionalType": "String",
-        "name": "BRANCH_NAME",
-        "defaultValue": "master",
-        "valueRequired": "True",
-        "description": "The branch name used in mhm-download, to retrieve the test domain data"
-      },
-      {
-        "@id": "#mhm-input-domain",
-        "@type": "FormalParameter",
-        "additionalType": "Integer",
-        "name": "DOMAIN",
-        "defaultValue": 1,
-        "valueRequired": "True",
-        "description": "The ID of the mHM test domain"
-      },
-      {
-        "@id": "#mhm-input-eval-period-duration-years",
-        "@type": "FormalParameter",
-        "additionalType": "Integer",
-        "name": "EVAL_PERIOD_DURATION_YEARS",
-        "defaultValue": 2,
-        "valueRequired": "True",
-        "description": "The duration of the evaluation period, this gets added to the start date for running the simulation"
-      },
-      {
-        "@id": "ro-crate-metadata.json",
-        "license": "https://spdx.org/licenses/Apache-2.0.html",
-        "author": [
-          {
+ROCRATE:
+  PATCH: |
+    {
+      "@graph": [
+        {
+          "@id": "./",
+          "license": "Apache-2.0",
+          "creator": {
             "@id": "https://orcid.org/0000-0001-8250-4074"
-          }
-        ]
-      },
-      {
-        "@id": "https://orcid.org/0000-0001-8250-4074",
-        "@type": "Person",
-        "affiliation": {
-            "@id": "mailto: https://ror.org/05sd8tv96"
+          },
+          "publisher": {
+            "@id": "https://ror.org/05sd8tv96"
+          },
+          "input": [
+            {
+              "@id": "#mhm-input-branch-name"
+            },
+            {
+              "@id": "#mhm-input-domain"
+            },
+            {
+              "@id": "#mhm-input-eval-period-duration-years"
+            }
+          ],
+          "output": [],
+          ]
         },
-        "contactPoint": {
-            "@id": "mailto: bruno.depaulakinoshita@bsc.es"
+        {
+          "@id": "#mhm-input-branch-name",
+          "@type": "FormalParameter",
+          "additionalType": "String",
+          "name": "BRANCH_NAME",
+          "defaultValue": "master",
+          "valueRequired": "True",
+          "description": "The branch name used in mhm-download, to retrieve the test domain data"
         },
-        "name": "Bruno P. Kinoshita"
-      },
-      {
-          "@id": "mailto: bruno.depaulakinoshita@bsc.es",
-          "@type": "ContactPoint",
-          "contactType": "Author",
-          "email": "bruno.depaulakinoshita@bsc.es",
-          "identifier": "bruno.depaulakinoshita@bsc.es",
-          "url": "https://orcid.org/0000-0001-8250-4074"
-      },
-      {
-          "@id": "https://ror.org/05sd8tv96",
-          "@type": "Organization",
-          "name": "Barcelona Supercomputing Center"
-      }
-    ]
-  }
+        {
+          "@id": "#mhm-input-domain",
+          "@type": "FormalParameter",
+          "additionalType": "Integer",
+          "name": "DOMAIN",
+          "defaultValue": 1,
+          "valueRequired": "True",
+          "description": "The ID of the mHM test domain"
+        },
+        {
+          "@id": "#mhm-input-eval-period-duration-years",
+          "@type": "FormalParameter",
+          "additionalType": "Integer",
+          "name": "EVAL_PERIOD_DURATION_YEARS",
+          "defaultValue": 2,
+          "valueRequired": "True",
+          "description": "The duration of the evaluation period, this gets added to the start date for running the simulation"
+        },
+        {
+          "@id": "ro-crate-metadata.json",
+          "license": "https://spdx.org/licenses/Apache-2.0.html",
+          "author": [
+            {
+              "@id": "https://orcid.org/0000-0001-8250-4074"
+            }
+          ]
+        },
+        {
+          "@id": "https://orcid.org/0000-0001-8250-4074",
+          "@type": "Person",
+          "affiliation": {
+              "@id": "mailto: https://ror.org/05sd8tv96"
+          },
+          "contactPoint": {
+              "@id": "mailto: bruno.depaulakinoshita@bsc.es"
+          },
+          "name": "Bruno P. Kinoshita"
+        },
+        {
+            "@id": "mailto: bruno.depaulakinoshita@bsc.es",
+            "@type": "ContactPoint",
+            "contactType": "Author",
+            "email": "bruno.depaulakinoshita@bsc.es",
+            "identifier": "bruno.depaulakinoshita@bsc.es",
+            "url": "https://orcid.org/0000-0001-8250-4074"
+        },
+        {
+            "@id": "https://ror.org/05sd8tv96",
+            "@type": "Organization",
+            "name": "Barcelona Supercomputing Center"
+        }
+      ]
+    }
+  OUTPUT:
+    - "%PROJDIR%/*.gif"

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -1,4 +1,9 @@
 ROCRATE:
+  # INPUT:
+  #   - name: "DATELIST"
+  #     value: "%EXPERIMENT.DATELIST%"
+  #     additionalType: "String"
+  #     valueRequired: "True"
   PATCH: |
     {
       "@graph": [
@@ -10,47 +15,19 @@ ROCRATE:
           },
           "publisher": {
             "@id": "https://ror.org/05sd8tv96"
-          },
-          "input": [
-            {
-              "@id": "#mhm-input-branch-name"
-            },
-            {
-              "@id": "#mhm-input-domain"
-            },
-            {
-              "@id": "#mhm-input-eval-period-duration-years"
-            }
-          ],
-          "output": [],
-          ]
+          }
         },
         {
-          "@id": "#mhm-input-branch-name",
-          "@type": "FormalParameter",
-          "additionalType": "String",
-          "name": "BRANCH_NAME",
-          "defaultValue": "master",
-          "valueRequired": "True",
-          "description": "The branch name used in mhm-download, to retrieve the test domain data"
+            "@id": "https://mhm.pages.ufz.de/mhm/stable/",
+            "@type": "SoftwareApplication",
+            "name": "mHM",
+            "softwareVersion": "5.12.1.dev228"
         },
         {
-          "@id": "#mhm-input-domain",
-          "@type": "FormalParameter",
-          "additionalType": "Integer",
-          "name": "DOMAIN",
-          "defaultValue": 1,
-          "valueRequired": "True",
-          "description": "The ID of the mHM test domain"
-        },
-        {
-          "@id": "#mhm-input-eval-period-duration-years",
-          "@type": "FormalParameter",
-          "additionalType": "Integer",
-          "name": "EVAL_PERIOD_DURATION_YEARS",
-          "defaultValue": 2,
-          "valueRequired": "True",
-          "description": "The duration of the evaluation period, this gets added to the start date for running the simulation"
+          "@id": "#create-action",
+          "@type": "CreateAction",
+          "name": "Run mHM",
+          "instrument": { "@id": "https://mhm.pages.ufz.de/mhm/stable/" }
         },
         {
           "@id": "ro-crate-metadata.json",
@@ -87,5 +64,3 @@ ROCRATE:
         }
       ]
     }
-  OUTPUT:
-    - "%PROJDIR%/*.gif"

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -9,7 +9,45 @@ ROCRATE: |
         },
         "publisher": {
           "@id": "https://ror.org/05sd8tv96"
-        }
+        },
+        "input": [
+          {
+            "@id": "#mhm-input-branch-name"
+          },
+          {
+            "@id": "#mhm-input-domain"
+          },
+          {
+            "@id": "#mhm-input-eval-period-duration-years"
+          }
+        ]
+      },
+      {
+        "@id": "#mhm-input-branch-name",
+        "@type": "FormalParameter",
+        "additionalType": "String",
+        "name": "BRANCH_NAME",
+        "defaultValue": "master",
+        "valueRequired": "True",
+        "description": "The branch name used in mhm-download, to retrieve the test domain data"
+      },
+      {
+        "@id": "#mhm-input-domain",
+        "@type": "FormalParameter",
+        "additionalType": "Integer",
+        "name": "DOMAIN",
+        "defaultValue": 1,
+        "valueRequired": "True",
+        "description": "The ID of the mHM test domain"
+      },
+      {
+        "@id": "#mhm-input-eval-period-duration-years",
+        "@type": "FormalParameter",
+        "additionalType": "Integer",
+        "name": "EVAL_PERIOD_DURATION_YEARS",
+        "defaultValue": 2,
+        "valueRequired": "True",
+        "description": "The duration of the evaluation period, this gets added to the start date for running the simulation"
       },
       {
         "@id": "ro-crate-metadata.json",

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -1,0 +1,48 @@
+ROCRATE: |
+  {
+    "@graph": [
+      {
+        "@id": "./",
+        "license": "Apache-2.0",
+        "creator": {
+          "@id": "https://orcid.org/0000-0001-8250-4074"
+        },
+        "publisher": {
+          "@id": "https://ror.org/05sd8tv96"
+        }
+      },
+      {
+        "@id": "ro-crate-metadata.json",
+        "license": "https://spdx.org/licenses/Apache-2.0.html",
+        "author": [
+          {
+            "@id": "https://orcid.org/0000-0001-8250-4074"
+          }
+        ]
+      },
+      {
+        "@id": "https://orcid.org/0000-0001-8250-4074",
+        "@type": "Person",
+        "affiliation": {
+            "@id": "mailto: https://ror.org/05sd8tv96"
+        },
+        "contactPoint": {
+            "@id": "mailto: bruno.depaulakinoshita@bsc.es"
+        },
+        "name": "Bruno P. Kinoshita"
+      },
+      {
+          "@id": "mailto: bruno.depaulakinoshita@bsc.es",
+          "@type": "ContactPoint",
+          "contactType": "Author",
+          "email": "bruno.depaulakinoshita@bsc.es",
+          "identifier": "bruno.depaulakinoshita@bsc.es",
+          "url": "https://orcid.org/0000-0001-8250-4074"
+      },
+      {
+          "@id": "https://ror.org/05sd8tv96",
+          "@type": "Organization",
+          "name": "Barcelona Supercomputing Center"
+      }
+    ]
+  }

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -18,21 +18,14 @@ ROCRATE:
           }
         },
         {
-            "@id": "https://mhm.pages.ufz.de/mhm/stable/",
-            "@type": "SoftwareApplication",
-            "name": "mHM",
-            "softwareVersion": "5.12.1.dev228"
-        },
-        {
           "@id": "#create-action",
           "@type": "CreateAction",
           "name": "Run mHM",
-          "instrument": { "@id": "https://mhm.pages.ufz.de/mhm/stable/" },
+          "instrument": { "@id": "workflow.yml" },
           "agent": { "@id": "https://orcid.org/0000-0001-8250-4074" }
         },
         {
           "@id": "ro-crate-metadata.json",
-          "license": "https://spdx.org/licenses/Apache-2.0.html",
           "author": [
             {
               "@id": "https://orcid.org/0000-0001-8250-4074"
@@ -43,7 +36,7 @@ ROCRATE:
           "@id": "https://orcid.org/0000-0001-8250-4074",
           "@type": "Person",
           "affiliation": {
-              "@id": "mailto: https://ror.org/05sd8tv96"
+              "@id": "https://ror.org/05sd8tv96"
           },
           "contactPoint": {
               "@id": "mailto: bruno.depaulakinoshita@bsc.es"

--- a/conf/rocrate.yaml
+++ b/conf/rocrate.yaml
@@ -1,9 +1,9 @@
 ROCRATE:
-  # INPUT:
-  #   - name: "DATELIST"
-  #     value: "%EXPERIMENT.DATELIST%"
-  #     additionalType: "String"
-  #     valueRequired: "True"
+  INPUTS:
+    # Add the extra keys to be exported.
+    - "MHM"
+  OUTPUTS:
+    - "*/*.gif"
   PATCH: |
     {
       "@graph": [
@@ -27,7 +27,8 @@ ROCRATE:
           "@id": "#create-action",
           "@type": "CreateAction",
           "name": "Run mHM",
-          "instrument": { "@id": "https://mhm.pages.ufz.de/mhm/stable/" }
+          "instrument": { "@id": "https://mhm.pages.ufz.de/mhm/stable/" },
+          "agent": { "@id": "https://orcid.org/0000-0001-8250-4074" }
         },
         {
           "@id": "ro-crate-metadata.json",

--- a/templates/remote_setup.sh
+++ b/templates/remote_setup.sh
@@ -54,6 +54,7 @@ do
     sed -i "s|test_domain/|${MHM_DATA_DIR}/test_domain/|" "mhm_${EVAL_PERIOD_START}_${EVAL_PERIOD_END}.nml"
   fi
 
+  cd %PLATFORMS.REMOTE.SCRATCH_DIR%
   MHM_SINGULARITY_SANDBOX_DIR="mhm_${EVAL_PERIOD_START}_${EVAL_PERIOD_END}"
   echo "Creating singularity sandbox ${MHM_SINGULARITY_SANDBOX_DIR}"
   if [[ ! -d "${MHM_SINGULARITY_SANDBOX_DIR}" ]]; then

--- a/templates/remote_setup.sh
+++ b/templates/remote_setup.sh
@@ -30,7 +30,7 @@ singularity inspect --all mhm.sif
 if [[ ! -d "data" ]]; then
   echo "Creating the data directories by cloning it from mHM Git repository"
 
-  singularity run mhm.sif mhm-download -b master -d 1 -p data
+  singularity run mhm.sif mhm-download -b %MHM.BRANCH_NAME% -d %MHM.DOMAIN% -p data
 
   cp ./*.nml ./data
 fi


### PR DESCRIPTION
Previously, in the draft MR in Autosubmit to support RO-Crate, users were supposed to provide an extra configuration file `rocrate.json` somewhere to be loaded by Autosubmit.

After working on the mHM workflow last week with @MuellerSeb (thanks again!), I realized it would be a lot easier if the RO-Crate configuration was part of the workflow configuration and included with it in Git.

That merge request is being modified, and tested with this PR. Once both are ready, we should be ready to finally get a review from the RO-Crate community :tada: (FYI @simleo)

I will update the commit in this PR a few times until I get the inputs  & outputs for the mHM workflow included in the RO-Crate JSON-LD.